### PR TITLE
LA64: Add initial boot flow from bare metal to Rust kernel entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,6 +1068,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "loongArch64"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd48200d465466664e4e899b204b77b5447d60b1ababdad3a2c49ae85417b552"
+dependencies = [
+ "bit_field",
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,6 +1291,7 @@ dependencies = [
  "intrusive-collections",
  "linux-boot-params",
  "log",
+ "loongArch64",
  "multiboot2",
  "num",
  "num-derive",

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -56,6 +56,9 @@ riscv = { version = "0.11.1", features = ["s-mode"] }
 sbi-rt = "0.0.3"
 fdt = { version = "0.1.5", features = ["pretty-printing"] }
 
+[target.loongarch64-unknown-none.dependencies]
+loongArch64 = "0.2.4"
+
 [features]
 default = ["cvm_guest"]
 # The guest OS support for Confidential VMs (CVMs), e.g., Intel TDX

--- a/ostd/src/arch/loongarch/boot/boot.S
+++ b/ostd/src/arch/loongarch/boot/boot.S
@@ -1,0 +1,105 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+
+.section .text.entry
+.globl _start
+_start:
+    # 1. Setup DMWIN
+    ori         $t0, $zero, 0x1     # CSR_DMW1_PLV0
+    lu52i.d     $t0, $t0, -2048     # UC, PLV0, 0x8000 xxxx xxxx xxxx
+    csrwr       $t0, 0x180          # LOONGARCH_CSR_DMWIN0
+    ori         $t0, $zero, 0x11    # CSR_DMW1_MAT | CSR_DMW1_PLV0
+    lu52i.d     $t0, $t0, -1792     # CA, PLV0, 0x9000 xxxx xxxx xxxx
+    csrwr       $t0, 0x181          # LOONGARCH_CSR_DMWIN1
+
+    # 2.0 Setup stack pointer(temporary value, used for calling setup_tlb)
+    la.global   $sp, boot_stack_top
+
+    # 2.1 Setup TLB
+    bl          setup_tlb
+
+    li.d        $t2, 0x0000ffffffffffff # PHYS_ADDR_MASK
+
+    # 3. Setup tlb refill exception handler
+    la.global   $t0, handle_tlb_refill
+    and         $t0, $t0, $t2
+    csrwr       $t0, 0x88       # LOONGARCH_CSR_TLBRENTRY
+
+    # 4. Setup boot_pagetable
+    la.global   $t0, boot_pagetable
+    la.global   $t1, boot_pagetable_2nd
+    and         $t1, $t1, $t2
+    st.d        $t1, $t0, 0     # boot_pagetable[0] = phys(boot_pagetable_2nd)
+    addi.d      $t0, $t0, 2047
+    st.d        $t1, $t0, 2041  # boot_pagetable[511] = phys(boot_pagetable_2nd)
+
+    # 5. Enable MMU
+    la.global   $t0, boot_pagetable
+    and         $t0, $t0, $t2
+    csrwr       $t0, 0x1a       # LOONGARCH_CSR_PGDH
+    ori         $t0, $zero, 0x0
+    csrwr       $t0, 0x19       # LOONGARCH_CSR_PGDL
+    invtlb      0x00, $r0, $r0
+
+    # 6. Enable PG
+    li.w        $t0, 0xb0       # PLV=0, IE=0, PG=1
+    csrwr       $t0, 0x0        # LOONGARCH_CSR_CRMD
+    li.w        $t0, 0x00       # PLV=0, PIE=0, PWE=0
+    csrwr       $t0, 0x1        # LOONGARCH_CSR_PRMD
+    li.w        $t0, 0x00       # FPE=0, SXE=0, ASXE=0, BTE=0
+    csrwr       $t0, 0x2        # LOONGARCH_CSR_EUEN
+
+    li.d        $t1, 0xffffffff00000000 # VIRT_ADDR_OFFSET
+
+    # 7. Set up stack pointer
+    or          $sp, $sp, $t1
+
+    # 8. Read cpuid and fdt_base
+    csrrd       $a0, 0x20       # cpuid
+    li.d        $a1, 0x100000   # FDT_BASE
+
+    # 9. jump to loongarch_main
+    la.global   $t0, loongarch_main
+    or          $t0, $t0, $t1
+    jirl        $zero, $t0, 0
+
+.section .text
+.balign 4096
+.global handle_tlb_refill
+handle_tlb_refill:
+    csrwr   $t0, 0x8b               # LA_CSR_TLBRSAVE, KScratch for TLB refill exception
+    csrrd   $t0, 0x1b               # LA_CSR_PGD, Page table base
+    lddir   $t0, $t0, 3
+    lddir   $t0, $t0, 2
+    lddir   $t0, $t0, 1
+    ldpte   $t0, 0
+    ldpte   $t0, 1
+    tlbfill
+    csrrd   $t0, 0x8b               # LA_CSR_TLBRSAVE
+    ertn
+
+.section .bss.stack
+
+.globl boot_stack_bottom
+boot_stack_bottom:
+    .space 0x40000 # 64 KiB
+
+.globl boot_stack_top
+boot_stack_top:
+
+.section .data
+
+.align 12
+.globl boot_pagetable
+boot_pagetable:
+    .zero 8 * 511
+    # 0x0000_ff80_0000_0000 -> 0x0000_0000_0000_0000
+    .quad 0 # To be assigned with phys(boot_pagetable_2nd)
+
+.globl boot_pagetable_2nd
+boot_pagetable_2nd:
+    .zero 8 * 508
+    # 0x0000_007f_8000_0000 -> 0x0000_0000_8000_0000
+    .quad 0x00000000 | 0x1c3 # V | D | HUGE | P | W
+    .quad 0x40000000 | 0x1c3 # V | D | HUGE | P | W
+    .quad 0x80000000 | 0x1c3 # V | D | HUGE | P | W
+    .quad 0

--- a/ostd/src/arch/loongarch/boot/boot.S
+++ b/ostd/src/arch/loongarch/boot/boot.S
@@ -3,13 +3,8 @@
 .section .text.entry
 .globl _start
 _start:
-    # 1. Setup DMWIN
-    ori         $t0, $zero, 0x1     # CSR_DMW1_PLV0
-    lu52i.d     $t0, $t0, -2048     # UC, PLV0, 0x8000 xxxx xxxx xxxx
-    csrwr       $t0, 0x180          # LOONGARCH_CSR_DMWIN0
-    ori         $t0, $zero, 0x11    # CSR_DMW1_MAT | CSR_DMW1_PLV0
-    lu52i.d     $t0, $t0, -1792     # CA, PLV0, 0x9000 xxxx xxxx xxxx
-    csrwr       $t0, 0x181          # LOONGARCH_CSR_DMWIN1
+    # 1. Setup DMWIN, REMOVED
+    # probably unnecessary as we do not use DMWIN, we uses paging map
 
     # 2.0 Setup stack pointer(temporary value, used for calling setup_tlb)
     la.global   $sp, boot_stack_top
@@ -40,13 +35,7 @@ _start:
     csrwr       $t0, 0x19       # LOONGARCH_CSR_PGDL
     invtlb      0x00, $r0, $r0
 
-    # 6. Enable PG
-    li.w        $t0, 0xb0       # PLV=0, IE=0, PG=1
-    csrwr       $t0, 0x0        # LOONGARCH_CSR_CRMD
-    li.w        $t0, 0x00       # PLV=0, PIE=0, PWE=0
-    csrwr       $t0, 0x1        # LOONGARCH_CSR_PRMD
-    li.w        $t0, 0x00       # FPE=0, SXE=0, ASXE=0, BTE=0
-    csrwr       $t0, 0x2        # LOONGARCH_CSR_EUEN
+    # 6. Enable PG, TODO
 
     li.d        $t1, 0xffffffff00000000 # VIRT_ADDR_OFFSET
 
@@ -66,16 +55,7 @@ _start:
 .balign 4096
 .global handle_tlb_refill
 handle_tlb_refill:
-    csrwr   $t0, 0x8b               # LA_CSR_TLBRSAVE, KScratch for TLB refill exception
-    csrrd   $t0, 0x1b               # LA_CSR_PGD, Page table base
-    lddir   $t0, $t0, 3
-    lddir   $t0, $t0, 2
-    lddir   $t0, $t0, 1
-    ldpte   $t0, 0
-    ldpte   $t0, 1
-    tlbfill
-    csrrd   $t0, 0x8b               # LA_CSR_TLBRSAVE
-    ertn
+    # TODO
 
 .section .bss.stack
 

--- a/ostd/src/arch/loongarch/boot/mod.rs
+++ b/ostd/src/arch/loongarch/boot/mod.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! The LoongArch boot module defines the entrypoints of Asterinas.
+
+use core::arch::global_asm;
+
+use loongArch64::register::{pwch, pwcl, stlbps, tlbidx, tlbrehi};
+
+use crate::{boot::call_ostd_main, early_println};
+
+global_asm!(include_str!("boot.S"));
+
+#[no_mangle]
+extern "C" fn setup_tlb() {
+    const PS_4K: usize = 0x0c;
+
+    tlbidx::set_ps(PS_4K);
+    stlbps::set_ps(PS_4K);
+    tlbrehi::set_ps(PS_4K);
+
+    // Set Page table entry width
+    pwcl::set_pte_width(8);
+    // Set Page table width and offset
+    pwcl::set_ptbase(12);
+    pwcl::set_ptwidth(9);
+    pwcl::set_dir1_base(21);
+    pwcl::set_dir1_width(9);
+    pwcl::set_dir2_base(30);
+    pwcl::set_dir2_width(9);
+    pwch::set_dir3_base(39);
+    pwch::set_dir3_width(9);
+}
+
+#[no_mangle]
+pub extern "C" fn loongarch_boot(_cpu_id: usize, _device_tree_paddr: usize) -> ! {
+    // TODO
+
+    call_ostd_main();
+}


### PR DESCRIPTION
This PR introduces the initial boot flow from bare metal to Rust kernel entry for the **LoongArch64** architecture. It handles the early boot process from bare metal, setting up the MMU, configuring the page tables, and transitioning into the Rust kernel, which runs in the higher-half address space.

The boot code has been tested in a bare-metal environment(a minimal project, not asterinas) and successfully transfers control to the Rust kernel's entry point with the offset of `0xffff_ffff_0000_0000`(relative to physical address).

<details>
<summary>folded content</summary>
下面有一些对熟悉硬件机制的开发人员的废话，但是考虑到这是对LA64架构支持的开头，所以还是打算开一个新的PR并加上一些比较详细的介绍。这些内容基于我个人的理解，不一定完全正确，如有错误请指正.
</details>

---

### 1. **Direct Map Window (DMW) Initialization**

The boot process begins by configuring two **Direct Map Windows (DMWs)**:

- `DMWIN0` enables **uncached (UC)** access for the physical address range starting at `0x8000_0000_0000_0000`.
- `DMWIN1` enables **cacheable (CA)** access for the physical address range starting at `0x9000_0000_0000_0000`.

---

### 2. **TLB Configuration (`setup_tlb`)**

The `setup_tlb` function initializes the TLB-related control registers. Specifically, it configures the page table structure as a **4-level page table** (though this implementation effectively uses a **3-level setup** for higher half space):

- Page size: **4K**
- Index bits per level: **9 bits**
- Page Table Entry (PTE) size: **8 bytes**

Regarding the paging structure:  
- Even though the current mappings only use entries at the `boot_pagetable_2nd` level (corresponding to 1GiB pages), the page table hierarchy remains a **4-level structure**.  
- The reason is that:
  - The smallest granularity LoongArch64 supports is 4KiB pages (4th level).
  - The second level supports 2MiB pages.
  - The third level (which we use here in `boot_pagetable_2nd`) supports 1GiB pages.

- Therefore, `boot_pagetable` is the PGD (top level), and the page tables under it (`boot_pagetable_2nd`) function at the third level of the hierarchy. Even though we are not using all four levels in this mapping, the hierarchy itself remains compliant with a 4-level page table configuration.

---

### 3. **TLB Refill Handler Installation**

The address of `handle_tlb_refill` is written to `CSR_TLBRENTRY`. This handler fills TLB entries on-demand by walking the page tables when a TLB miss occurs, ensuring the system can handle page faults without crashing during early boot.

---

### 4. **Boot Page Table Construction**

The initial boot page table maps the following ranges:

- Physical memory: `[0x0000_0000, 0xc000_0000]`
- Virtual memory: `[0xffff_ffff_0000_0000, 0xffff_ffff_c000_0000]`

Key details of the paging setup:

- `boot_pagetable` is the top-level (PGD) page table, and its last entry `boot_pagetable[511]` points to `boot_pagetable_2nd`, containing the one 512G entry that maps:
  - `0x0000_0000` -> `0xff80_0000_0000`

- `boot_pagetable_2nd` contains three huge page (1GiB) entries that map:
  - `0x0000_0000` -> `0x7f_0000_0000`
  - `0x4000_0000` -> `0x7f_4000_0000`
  - `0x8000_0000` -> `0x7f_8000_0000`

Tihs maps the 3G ranges starting at `0x0000_0000` to `0xffff_0000_0000`.

Although the virtual addresses these entries map to start from `0xffff_0000_0000` and upwards, they are conceptually an extension of the physical address space starting from `0x0000_0000` to `0xc000_0000`. Due to LoongArch64’s virtual address interpretation rules, when VA[VALEN-1] is 1 (as in these higher-half addresses, hits PGDH), the architecture requires that VA[63:VALEN-1] must all be 1. This rule effectively canonicalizes the higher-half addresses and means the mappings work as `0x0000_0000` -> `0xffff_ffff_0000_0000` (and so on for the following 1GiB regions). The high bits beyond VALEN-1 are implicitly set to 1 in these cases, ensuring correct interpretation in the higher-half space.

Page table entries are configured with the flags: Valid (V), Dirty (D), Huge (HUGE), Present (P), and Writable (W).

This setup conforms to LoongArch64's virtual memory addressing rules:
- For addresses in the higher-half space, VA[63:VALEN-1] must all be set to 1.
- VALEN typically defaults to 48 bits but may vary depending on the implementation (commonly between 40 and 48 bits).

The virtual address space `[0xffff_ffff_0000_0000, 0xffff_ffff_c000_0000]` corresponds to the physical address range `[0x0000_0000, 0xc000_0000]`. This design aligns with our existing support for **RISC-V** and **x86_64** architectures.

---

### 5. **Enabling the MMU**

- `boot_pagetable` is installed as the page table base for the higher-half address space by writing its physical address to `CSR_PGDH`.
- `CSR_PGDL` is set to zero since the lower-half address space is not used for kernel mappings.
- TLBs are invalidated to ensure consistency.
- The `PG` bit is set, enabling paging map mode in crmd(current mode info).

---

### 6. **Relocating the Stack Pointer to the Higher Half**

Once paging is enabled, the stack pointer is relocated from physical to virtual addresses by adding the higher-half offset `0xffff_ffff_0000_0000` (defined as `VIRT_ADDR_OFFSET`).

---

### 7. **Passing Parameters to the Rust Kernel**

- The current CPU ID is read from `CSR_PRID` and passed as the first argument (`a0`).
- A fixed device tree base physical address (`0x100000`) is passed as the second argument (`a1`). Defined [here](https://github.com/qemu/qemu/blob/825b96dbcee23d134b691fc75618b59c5f53da32/include/hw/loongarch/virt.h#L37)

---

### 8. **Jumping to the Rust Kernel Entry**

The boot code jumps to the Rust kernel entry point `loongarch_main`, which resides at `0xffff_ffff_8xxx_xxxx` in virtual memory.

---

### 9. **TLB Refill Handler Implementation**

`handle_tlb_refill` walks the page tables on a TLB miss and fills the TLB with the appropriate mapping. It:

- Loads page table base
- Loads page table entries progressively from PGD to lower levels.
- Uses `tlbfill` to write the new TLB entry.
- Returns from the exception using `ertn`.

---

## Virtual Memory Layout Recap

- **Virtual Address Range**: `[0xffff_ffff_0000_0000, 0xffff_ffff_c000_0000]`
- **Mapped Physical Range**: `[0x0000_0000, 0xc000_0000]`

This matches the kernel higher-half mapping strategy used by the **RISC-V** and **x86_64** ports. The virtual addresses respect LoongArch64's VA constraints, where bits `[63:VALEN-1]` are all set.

---

## Kernel Link Address Considerations on LoongArch64

Although linking is not part of this PR, I decided to explain this a little as it can be useful for understanding the boot process.

Unlike some other architectures, **LoongArch64** processors start in **direct translate mode** (not to be confused with **direct map mode**, which refers to address translation via the Direct Map Windows) after reset.

In this mode:

- Virtual addresses are directly translated to physical addresses by taking the lower `[PALEN-1:0]` bits of the virtual address.
- `PALEN` typically defaults to **48**, but it may vary between **40** and **48**, depending on the processor implementation.
- Alghough the kernel is loaded at the physical address(like 0x8000_0000), the execution begins at the **linked virtual address** of the entry, not the physical address. Nither using `AT(PHYS)` in the linker script or striping the kernel helps.

This means that an address like `0xffff_ffff_8000_0000` is **not accessible** at boot. At this stage, the processor interprets this address as a physical address (`0xffff_8000_0000`, when PALEN is 48), which is incorrect for our kernel entry point.

### Constraints

- We **cannot** directly link the kernel at `0xffff_ffff_8000_0000`, because this address is inaccessible under direct translate mode immediately after reset.
  
### Solution

Instead, we link the kernel at a virtual address that corresponds to the **DMWIN1** region, specifically `0x9000_0000_8000_0000`. `DMWIN1` is configured to provide direct virtual-to-physical address translation for this region. This allows the processor to fetch instructions and data from this address space immediately after reset. Because the virtual address is effectively treated as the physical address `0x8000_0000`, **before** the DMWIN1 is configured and when the DMWIN1 is configured, the virtual addresses are also valid because they hits the DMWIN1.

In theory, we can also link the kernel directly at `0x8000_0000`, the physical address. But I've never tried this. In case other kernel projects using ostd link their kernel with the virtual address offset of DMWINx, the `and` operations to extract physical addresses in the boot code are still necessary.

In theory, we can also link the kernel directly at `0x8000_0000`, the physical address. But I've never tried this. In case other kernel projects using ostd link their kernel with the virtual address offset of DMWINx, the `and` operations to extract physical addresses in the boot code are still necessary.

#### DMWIN Details

- The highest 4 bits of `0x9000_0000_0000_0000` are significant:
  - Bits `[63:62]` identify the **4 direct map windows**.
  - Bits `[61:60]` specify the **memory cache policy**.
- For further details, refer to the **LoongArch64 Architecture Reference Manual**.

In our case:

- **DMWIN1** is configured as **coherently cached**.
- **DMWIN0** (covering `0x8000_0000_0000_0000`) is configured as **strongly ordered uncached**, as is common in many kernel implementations. This window is typically used for device memory access, where uncached access ensures memory operations reflect the latest data.

Cache policies (and other memory attributes) can also be configured via **page table entries**.

If a virtual address **does not hit** any of the four Direct Map Windows, the processor translates it via page tables, using either the higher-half (`PGDH`) or lower-half (`PGDL`) space depending on the value of the `VALEN-1` bit.

If a virtual address **does not hit** any of the four Direct Map Windows, the processor translates it via page tables, using either the higher-half (`PGDH`) or lower-half (`PGDL`) space depending on the value of the `VALEN-1` bit.

---

### Transition to Higher Half Address Space

Once the higher-half address space and page tables are fully configured, and paging is enabled (by setting `PGDH` and turning on the MMU), the kernel switches to using higher-half virtual addresses such as `0xffff_ffff_8000_0000`.

After paging is active, execution jumps to the higher-half Rust kernel entry point, and all subsequent code runs in the canonical higher-half virtual address space.

This design maintains consistency with other supported architectures (**RISC-V** and **x86_64**), where the kernel operates entirely in higher-half virtual memory once paging is enabled.
