### PR TITLE
ostd: Fix a minor compilation failure for non x86_64 platforms  

### DIFF
--- a/ostd/src/mm/dma/dma_stream.rs
+++ b/ostd/src/mm/dma/dma_stream.rs
@@ -156,7 +156,7 @@ impl DmaStream {
                 if self.inner.is_cache_coherent {
                     return Ok(());
                 }
-                let start_va = crate::mm::paddr_to_vaddr(self.inner.segment.paddr()) as *const u8;
+                let start_va = crate::mm::paddr_to_vaddr(self.inner.segment.start_paddr()) as *const u8;
                 // TODO: Query the CPU for the cache line size via CPUID, we use 64 bytes as the cache line size here.
                 for i in _byte_range.step_by(64) {
                     // TODO: Call the cache line flush command in the corresponding architecture.


### PR DESCRIPTION
I encountered this issue when porting ostd to la64, but this issue also affects rv64.

## Description​

The `paddr()` method was originally part of the `HasPaddr` interface. However, the implementation of the `HasPaddr` interface for `Segment<T>` was removed in the commit c9a37ccab1caf22f3d392df50c447516f06521b4. This removal led to compilation failures.​

Upon examination, it was found that within the original paddr method, it directly called `self.start_paddr()`.​

## Solution​

As a temporary fix, this PR changes the method call from `paddr()` to `start_paddr()`. This adjustment resolves the compilation issues caused by the removal of the `HasPaddr` implementation for `Segment<T>`.​

## Architecture Impact​

It's important to note that this problem only affects non - x86_64 architectures. The relevant code is guarded by `cfg(not(target_arch = "x86_64"))` condition, which means that x86_64 architectures are not impacted by this particular issue, and this fix is specifically targeted at non - x86_64 platforms.
