### PR TITLE
ostd: Disable MSIX on non-x86_64 platforms to fix build issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 # 🚀 欢迎登上OS大赛的星绽快车！
 
 你是否憧憬亲手打造一个既酷炫又安全的操作系统？是否想用Rust语言在系统编程的宇宙中留下自己的轨迹？欢迎选择基于星绽参加2025年的OS大赛，使用Rust语言在探索OS领域的星辰大海！
+
 ## 🌠 为什么选择星绽？
 
-[星绽](https://github.com/asterinas/asterinas)是一个与Linux兼容、但比Linux更安全可靠的OS内核。目前，星绽支持两个CPU体系架构（amd64和riscv64），实现了190个Linux系统调用，5个文件系统（包括Ext2和extFAT32），3种网络socket类型（包括TCP、UDP、Unix等），常用Virtio驱动，第一方代码（不包括依赖）合计超过10万行。
+[星绽](https://github.com/asterinas/asterinas)是一个与Linux兼容、但比Linux更安全可靠的OS内核。目前，星绽支持两个CPU体系架构（amd64和riscv64），实现了190个Linux系统调用，5个文件系统（包括Ext2和extFAT32），3种网络socket类型（包括TCP、UDP、Unix等），常用Virtio驱动，第一方代码（不包括依赖）合计超过10万行。项目的2024年度进展报告[见这里](https://asterinas.github.io/2025/01/20/asterinas-in-2024.html)。
 
 相比其他基于Rust语言的OS内核，星绽具有如下特色：
 
@@ -32,6 +33,8 @@
 （奖励规则后续会细化，奖品也可能会所有调整，最终解释权归星绽社区，敬请关注本仓库后续正式公告！）
 
 在克服了以上公共的基本要求之后，我们期待各位参赛同学自由选择感兴趣的、有挑战的OS功能和特性，把他们加到星绽中。祝大家赛出风格，赛出水平，有所收获，共同进步！
+
+如有任何问题，欢迎在本仓库上提Issue，或者加微信交流（姓名：蚂蚁集团 田洪亮，Github/微信ID: tatetian）。
 
 -----
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,40 @@
+✨亲爱的开发者小伙伴✨，欢迎来到2025年OS大赛特供版星绽仓库。
+
+# 🚀 欢迎登上OS大赛的星绽快车！
+
+你是否憧憬亲手打造一个既酷炫又安全的操作系统？是否想用Rust语言在系统编程的宇宙中留下自己的轨迹？欢迎选择基于星绽参加2025年的OS大赛，使用Rust语言在探索OS领域的星辰大海！
+## 🌠 为什么选择星绽？
+
+[星绽](https://github.com/asterinas/asterinas)是一个与Linux兼容、但比Linux更安全可靠的OS内核。目前，星绽支持两个CPU体系架构（amd64和riscv64），实现了190个Linux系统调用，5个文件系统（包括Ext2和extFAT32），3种网络socket类型（包括TCP、UDP、Unix等），常用Virtio驱动，第一方代码（不包括依赖）合计超过10万行。
+
+相比其他基于Rust语言的OS内核，星绽具有如下特色：
+
+* **首创[框内核架构](https://asterinas.github.io/book/kernel/the-framekernel-architecture.html)**: 所有unsafe Rust代码被限制在了一个极小的OS开发框架中（名为[OSTD](https://asterinas.github.io/book/ostd/index.html)），绝大多数OS功能使用纯safe Rust开发，让你对代码更加自信。
+* **形式化验证加持**：OS开发框架中涉及unsafe的部分关键模块[已被形式化证明](https://asterinas.github.io/2025/02/13/towards-practical-formal-verification-for-a-general-purpose-os-in-rust.html)，内存安全更加有保障。
+* **性能比肩Linux**：实现代码经过高度优化，在[LMbench等基准测试上比肩Linux](https://asterinas.github.io/benchmark/)。
+* **开箱即用工具箱**：为OS开发者量身定制了开发工具箱（名为[OSDK](https://asterinas.github.io/book/osdk/guide/index.html)），令Rust OS开发像Rust应用开发一样丝滑。
+
+## 💰 咦！参与还有奖？
+
+今年是星绽第一次作为OS大赛的内核赛道的基础OS，而大赛的评测有一些统一要求，目前星绽尚未满足，这意味着每一个选择星绽作为基础OS的参赛小组都有一些共同需要做的事情，比如：
+
+1. 改造Makefile及其他基础设施以满足评测平台的提交要求；
+2. 增加LoongArch的支持，包括代码、测试、CI等；
+3. 为了运行官方测试集，修复bug或增加功能。
+
+我们欢迎参赛同学们将为了满足以上公共需求的代码提交到本代码仓库（星绽主仓库更佳！）。我们合并代码时会综合考虑（1）时效性（越早提交越好），（2）质量（可读性、干净和可维护），（3）原子性（每个PR或commit只做一件不可细分的事情）。
+
+在初赛阶段结束之前，我们会评出贡献最大的一些同学，并提供一些物质奖励以表彰你们的贡献：
+1. 一等奖（1名）：Macbook Air 13寸 M4芯片
+2. 二等奖（2名）：iPad Mini A17 Pro
+3. 三等奖（3名）：Air Pods 4 主动降噪
+
+（奖励规则后续会细化，奖品也可能会所有调整，最终解释权归星绽社区，敬请关注本仓库后续正式公告！）
+
+在克服了以上公共的基本要求之后，我们期待各位参赛同学自由选择感兴趣的、有挑战的OS功能和特性，把他们加到星绽中。祝大家赛出风格，赛出水平，有所收获，共同进步！
+
+-----
+
 <p align="center">
     <img src="docs/src/images/logo_en.svg" alt="asterinas-logo" width="620"><br>
     A secure, fast, and general-purpose OS kernel written in Rust and compatible with Linux<br/>

--- a/osdk/src/arch.rs
+++ b/osdk/src/arch.rs
@@ -18,11 +18,18 @@ pub enum Arch {
     RiscV64,
     #[serde(rename = "x86_64")]
     X86_64,
+    #[serde(rename = "loongarch64")]
+    LoongArch64,
 }
 
 impl ValueEnum for Arch {
     fn value_variants<'a>() -> &'a [Self] {
-        &[Arch::Aarch64, Arch::RiscV64, Arch::X86_64]
+        &[
+            Arch::Aarch64,
+            Arch::RiscV64,
+            Arch::X86_64,
+            Arch::LoongArch64,
+        ]
     }
 
     fn to_possible_value(&self) -> Option<PossibleValue> {
@@ -30,6 +37,7 @@ impl ValueEnum for Arch {
             Arch::Aarch64 => Some(PossibleValue::new(self.to_str())),
             Arch::RiscV64 => Some(PossibleValue::new(self.to_str())),
             Arch::X86_64 => Some(PossibleValue::new(self.to_str())),
+            Arch::LoongArch64 => Some(PossibleValue::new(self.to_str())),
         }
     }
 }
@@ -41,6 +49,7 @@ impl Arch {
             Arch::Aarch64 => "aarch64-unknown-none",
             Arch::RiscV64 => "riscv64gc-unknown-none-elf",
             Arch::X86_64 => "x86_64-unknown-none",
+            Arch::LoongArch64 => "loongarch64-unknown-none",
         }
     }
 
@@ -49,6 +58,7 @@ impl Arch {
             Arch::Aarch64 => "qemu-system-aarch64",
             Arch::RiscV64 => "qemu-system-riscv64",
             Arch::X86_64 => "qemu-system-x86_64",
+            Arch::LoongArch64 => "qemu-system-loongarch64",
         }
     }
 
@@ -57,6 +67,7 @@ impl Arch {
             Arch::Aarch64 => "aarch64",
             Arch::RiscV64 => "riscv64",
             Arch::X86_64 => "x86_64",
+            Arch::LoongArch64 => "loongarch64",
         }
     }
 }
@@ -89,6 +100,7 @@ pub fn get_default_arch() -> Arch {
             "aarch64" => Arch::Aarch64,
             "riscv64gc" => Arch::RiscV64,
             "x86_64" => Arch::X86_64,
+            "loongarch64" => Arch::LoongArch64,
             _ => panic!("The host has an unsupported native architecture"),
         },
         None => panic!("`rustc -vV` gave a host with unknown format"),

--- a/ostd/src/bus/pci/capability/mod.rs
+++ b/ostd/src/bus/pci/capability/mod.rs
@@ -6,13 +6,16 @@
 
 use alloc::vec::Vec;
 
-use self::{msix::CapabilityMsixData, vendor::CapabilityVndrData};
+#[cfg(target_arch = "x86_64")]
+use self::msix::CapabilityMsixData;
+use self::vendor::CapabilityVndrData;
 use super::{
     cfg_space::{PciDeviceCommonCfgOffset, Status},
     common_device::PciCommonDevice,
     PciDeviceLocation,
 };
 
+#[cfg(target_arch = "x86_64")]
 pub mod msix;
 pub mod vendor;
 
@@ -64,6 +67,7 @@ pub enum CapabilityData {
     Secdev,
     /// Id:0x10, PCI Express
     Exp,
+    #[cfg(target_arch = "x86_64")]
     /// Id:0x11, MSI-X
     Msix(CapabilityMsixData),
     /// Id:0x12, SATA Data/Index Conf
@@ -129,6 +133,7 @@ impl Capability {
                 0x0E => CapabilityData::Agp3,
                 0x0F => CapabilityData::Secdev,
                 0x10 => CapabilityData::Exp,
+                #[cfg(target_arch = "x86_64")]
                 0x11 => CapabilityData::Msix(CapabilityMsixData::new(dev, cap_ptr)),
                 0x12 => CapabilityData::Sata,
                 0x13 => CapabilityData::Af,


### PR DESCRIPTION
MSIX depends on interrupt remapping, which we currently only support on x86_64. Disabling MSIX for other architectures helps avoid unnecessary build failures.

This PR is a quick fix to get things compiling again on non-x86_64 targets.
