### PR TITLE
Make MSI-X an optional feature for virtio

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -70,5 +70,11 @@ all = ["cvm_guest"]
 
 cvm_guest = ["dep:tdx-guest", "ostd/cvm_guest"]
 
+# Specifying dependencies conditioned on features is not supported.
+# Please see https://github.com/rust-lang/cargo/issues/1197 for more details.
+[target.'cfg(target_arch = "x86_64")'.dependencies.aster-virtio]
+path = "comps/virtio"
+features = ["msix"]
+
 [lints]
 workspace = true

--- a/kernel/comps/virtio/Cargo.toml
+++ b/kernel/comps/virtio/Cargo.toml
@@ -22,5 +22,8 @@ component = { path = "../../libs/comp-sys/component" }
 log = "0.4"
 int-to-c-enum = { path = "../../libs/int-to-c-enum" }
 
+[features]
+msix = ["ostd/msix"]
+
 [lints]
 workspace = true

--- a/kernel/comps/virtio/Cargo.toml
+++ b/kernel/comps/virtio/Cargo.toml
@@ -23,6 +23,8 @@ log = "0.4"
 int-to-c-enum = { path = "../../libs/int-to-c-enum" }
 
 [features]
+default = ["msix"]
+
 msix = ["ostd/msix"]
 
 [lints]

--- a/kernel/comps/virtio/src/transport/pci/mod.rs
+++ b/kernel/comps/virtio/src/transport/pci/mod.rs
@@ -5,6 +5,8 @@ pub mod common_cfg;
 pub mod device;
 pub mod driver;
 pub mod legacy;
+
+#[cfg(feature = "msix")]
 pub(super) mod msix;
 
 use alloc::sync::Arc;

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -57,7 +57,7 @@ sbi-rt = "0.0.3"
 fdt = { version = "0.1.5", features = ["pretty-printing"] }
 
 [features]
-default = ["cvm_guest"]
+default = ["cvm_guest", "msix"]
 # The guest OS support for Confidential VMs (CVMs), e.g., Intel TDX
 cvm_guest = ["dep:tdx-guest", "dep:iced-x86"]
 msix = []

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -60,6 +60,7 @@ fdt = { version = "0.1.5", features = ["pretty-printing"] }
 default = ["cvm_guest"]
 # The guest OS support for Confidential VMs (CVMs), e.g., Intel TDX
 cvm_guest = ["dep:tdx-guest", "dep:iced-x86"]
+msix = []
 
 [lints]
 workspace = true

--- a/ostd/src/bus/pci/capability/mod.rs
+++ b/ostd/src/bus/pci/capability/mod.rs
@@ -6,13 +6,16 @@
 
 use alloc::vec::Vec;
 
-use self::{msix::CapabilityMsixData, vendor::CapabilityVndrData};
+#[cfg(feature = "msix")]
+use self::msix::CapabilityMsixData;
+use self::vendor::CapabilityVndrData;
 use super::{
     cfg_space::{PciDeviceCommonCfgOffset, Status},
     common_device::PciCommonDevice,
     PciDeviceLocation,
 };
 
+#[cfg(feature = "msix")]
 pub mod msix;
 pub mod vendor;
 
@@ -64,6 +67,7 @@ pub enum CapabilityData {
     Secdev,
     /// Id:0x10, PCI Express
     Exp,
+    #[cfg(feature = "msix")]
     /// Id:0x11, MSI-X
     Msix(CapabilityMsixData),
     /// Id:0x12, SATA Data/Index Conf
@@ -129,6 +133,7 @@ impl Capability {
                 0x0E => CapabilityData::Agp3,
                 0x0F => CapabilityData::Secdev,
                 0x10 => CapabilityData::Exp,
+                #[cfg(feature = "msix")]
                 0x11 => CapabilityData::Msix(CapabilityMsixData::new(dev, cap_ptr)),
                 0x12 => CapabilityData::Sata,
                 0x13 => CapabilityData::Af,


### PR DESCRIPTION
Currently, MSI-X support is only implemented for x86_64, causing build failures on other platforms.
This patch makes MSI-X support an optional feature (msix) in both ostd and virtio, and guards relevant code with #[cfg(feature = "msix")].

This resolves build issues on non-x86_64 targets while preserving MSI-X functionality where supported.
